### PR TITLE
Fix segmentation fault in case setlocale returns NULL

### DIFF
--- a/amdcovc.cpp
+++ b/amdcovc.cpp
@@ -3210,7 +3210,7 @@ try
     
     {
         const char* loc = setlocale(LC_CTYPE, "");
-        const size_t locLen = ::strlen(loc);
+        const size_t locLen = (loc>0) ? ::strlen(loc) : 0;
         terminalUTF8 = locLen>=6 && ::strcmp(loc+locLen-6, ".UTF-8")==0;
         loc = setlocale(LC_CTYPE, "C");
     }


### PR DESCRIPTION
strlen can segfault in case setlocale returns NULL, which can happen on some systems with limited configuration